### PR TITLE
Update exampleSite-images due to dep update

### DIFF
--- a/exampleSite-images/config.toml
+++ b/exampleSite-images/config.toml
@@ -78,6 +78,9 @@ disabled = true
 replacements = "github.com/danielfdickinson/metadata-mod-hugo-dfd -> ../.."
 
 [[module.imports]]
+path = "github.com/danielfdickinson/link-handling-mod-hugo-dfd"
+
+[[module.imports]]
 path = "github.com/danielfdickinson/image-handling-mod-hugo-dfd"
 
 [[module.imports]]

--- a/exampleSite-images/go.mod
+++ b/exampleSite-images/go.mod
@@ -3,6 +3,7 @@ module github.com/danielfdickinson/hmetadata-mod-hugo-dfd/exampleSite
 go 1.17
 
 require (
-	github.com/danielfdickinson/image-handling-mod-hugo-dfd v0.4.0 // indirect
+	github.com/danielfdickinson/image-handling-mod-hugo-dfd v0.4.2-0.20220711095531-eab58a8ce52e // indirect
+	github.com/danielfdickinson/link-handling-mod-hugo-dfd v0.3.1 // indirect
 	github.com/danielfdickinson/minimal-test-theme-hugo-dfd v0.3.4-0.20220415212654-4ef7a9ea243f // indirect
 )

--- a/exampleSite-images/go.sum
+++ b/exampleSite-images/go.sum
@@ -1,4 +1,6 @@
-github.com/danielfdickinson/image-handling-mod-hugo-dfd v0.4.0 h1:rxwwdRfve+i3gIJzqo0UK9TlMkYY4unoh7XAqMjZawM=
-github.com/danielfdickinson/image-handling-mod-hugo-dfd v0.4.0/go.mod h1:WFjQtUdhBGFndQVaMo5UoXcKRxyAZ6dtxOea27J0ccE=
+github.com/danielfdickinson/image-handling-mod-hugo-dfd v0.4.2-0.20220711095531-eab58a8ce52e h1:8BI31Z9O562nX/LKEZNdXFCKVnq5PXrZeygkiLeaHiU=
+github.com/danielfdickinson/image-handling-mod-hugo-dfd v0.4.2-0.20220711095531-eab58a8ce52e/go.mod h1:r2HhhIAUbD/hO0YgvRhIoZsvE096nWD9mdcSz4Oa25c=
+github.com/danielfdickinson/link-handling-mod-hugo-dfd v0.3.1 h1:kujYarppbu4laEsv1P53xGGgkep+bQBsO7FhPIj98Sg=
+github.com/danielfdickinson/link-handling-mod-hugo-dfd v0.3.1/go.mod h1:inb1U/NMQWMjoDBEhpabB/cI06SkgWnbM4dHKFHCG60=
 github.com/danielfdickinson/minimal-test-theme-hugo-dfd v0.3.4-0.20220415212654-4ef7a9ea243f h1:YrNfYdjGs8Ncm2wyRUS7gm4dWFFAASu2UB5Jx/uMYTg=
 github.com/danielfdickinson/minimal-test-theme-hugo-dfd v0.3.4-0.20220415212654-4ef7a9ea243f/go.mod h1:yu/RUtbx29O/vvbthJjLqXXu7cdE/e8XZ3rVvh+01BM=


### PR DESCRIPTION
image-handling no longer depends on link-handling so we must add it since
we depend on it for the README as page on site.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>